### PR TITLE
Removes "importlib" from requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
         readme="README.md",
         author="Shell of OMEGA",
         license="MIT",
-        install_requires=["aiohttp==3.7.4.post0","aioconsole==0.3.3", "websockets==10.1", "importlib", "requests"],
+        install_requires=["aiohttp==3.7.4.post0","aioconsole==0.3.3", "websockets==10.1", "requests"],
         setup_requires=['pytest-runner'],
         tests_require=['pytest'],
         test_suite='tests',


### PR DESCRIPTION
Most people have python3, which already has importlib preinstalled. The removal of this requirement would allow people using python3 to pip install the package without encountering any errors.