### PR TITLE
fixed pypi link

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ bot.run(token)
 ## Some Useful Links
 - [Documentation](https://github.com/Shell1010/Selfcord/wiki)
 - [Other Documentation (messy)](https://github.com/Shell1010/Selfcord/tree/main/docs)
-- [PyPi](https://pypi.org/project/selfcord/)
+- [PyPi](https://pypi.org/project/selfcord.py/)
 - [Official Discord Server](https://discord.gg/FCFnnBGzkg)
 - [A simple selfbot designed to showcase the library's features](https://github.com/Shell1010/Aeterna-Selfbot)
 


### PR DESCRIPTION
added the ".py" to the end of the link cuz the old one just said "selfcord"