### PR TITLE
Message: store the received JSON data; get actual message's timestamp

### DIFF
--- a/selfcord/models/message.py
+++ b/selfcord/models/message.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import datetime
 import logging
 import random
 import time

--- a/selfcord/models/message.py
+++ b/selfcord/models/message.py
@@ -198,6 +198,8 @@ class Message:
         Args:
             data (dict): JSON data from gateway
         """
+        self._data = data
+
         self.tts = data.get("tts")
         self.referenced_message = data.get("referenced_message")
         self.author = User(data.get("author"), self.bot, self.http)
@@ -219,7 +221,8 @@ class Message:
             else:
                 self.components.append(component)
 
-        self.timestamp = time.time()
+        timestamp = data.get('timestamp')
+        self.timestamp = datetime.datetime.strptime(timestamp, '%Y-%m-%dT%H:%M:%S.%f%z').timestamp() if timestamp else time.time()
         self.channel_id = data.get("channel_id")
 
         attachments = data.get("attachments")


### PR DESCRIPTION
There's a lot of fields in the actual JSON that aren't accessible from the Message object instance. I decided to keep it in the  `_data` variable.  

Regarding the message timestamp:  
Not sure if there's a need to use `time.time()`, but I kept it in case there would be no timestamp in the data.  
Feel free to remove it by keeping it just like that:
```
self.timestamp = datetime.datetime.strptime(data.get('timestamp'), '%Y-%m-%dT%H:%M:%S.%f%z').timestamp()
```

Though it will crash if there will be no `timestamp` key.